### PR TITLE
Add missing .O files Target on Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,7 @@ DEPENDS	:=	$(OFILES:.o=.d)
 all	:	$(OUTPUT).wuhb
 
 $(OUTPUT).wuhb : $(OUTPUT).rpx
+$(OUTPUT).rpx : $(OFILES)
 
 $(OFILES_SRC)	: $(HFILES_BIN)
 


### PR DESCRIPTION
First of all:
Love your project! Its helping me a lot on my wii u learning process. 


Now, seems like the build targets were missing the .o files (.elf) from being generated.
If you already have the .elf file in the directory the `make clean` does not delete it, and a newer `make all`  command would just find that older .elf which is probably why it might look like this build target is not needed.

Anyway, bringing it back so it allows the project to be linked properly. (Without this the linker complains about all the missing object files)

![image](https://github.com/user-attachments/assets/935cdc94-707a-4808-8d37-c5b3182ec27c)
> Looks pretty neat!